### PR TITLE
Upgrade tests and CI to Go 1.25+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,25 +26,20 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.12
 
   test:
     name: Test
     strategy:
       matrix:
-        go: [ '1.24.x', '1.23.x' ]
+        go: [ '1.26.x', '1.25.x' ]
         os: [ ubuntu-latest ]
-        include:
-          - go: '1.24.x'
-            go_experiment: 'nocoverageredesign'
-          - go: '1.23.x'
-            go_experiment: 'nocoverageredesign'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -56,8 +51,6 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Test
-        env:
-          GOEXPERIMENT: ${{ matrix.go_experiment }}
         run: go test ./... -v -race -coverprofile=./cover.out
 
       - name: Check Test Coverage

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -11,6 +11,7 @@ package singleflight_test
 import (
 	"errors"
 	"testing"
+	"testing/synctest"
 
 	"github.com/brunomvsouza/singleflight"
 )
@@ -48,57 +49,61 @@ func TestGroup_Do(t *testing.T) {
 
 func TestGroup_DoChan(t *testing.T) {
 	t.Run("single call", func(t *testing.T) {
-		var g singleflight.Group[string, int]
-		ch := g.DoChan("key", func() (int, error) {
-			return 42, nil
-		})
+		synctest.Test(t, func(t *testing.T) {
+			var g singleflight.Group[string, int]
+			ch := g.DoChan("key", func() (int, error) {
+				return 42, nil
+			})
 
-		res := <-ch
-		if got, want := res.Val, 42; got != want {
-			t.Errorf("DoChan = %v; want %v", got, want)
-		}
-		if res.Err != nil {
-			t.Errorf("DoChan error = %v", res.Err)
-		}
-		if res.Shared {
-			t.Errorf("DoChan shared = true; want false")
-		}
+			res := <-ch
+			if got, want := res.Val, 42; got != want {
+				t.Errorf("DoChan = %v; want %v", got, want)
+			}
+			if res.Err != nil {
+				t.Errorf("DoChan error = %v", res.Err)
+			}
+			if res.Shared {
+				t.Errorf("DoChan shared = true; want false")
+			}
+		})
 	})
 
 	t.Run("concurrent calls", func(t *testing.T) {
-		var g singleflight.Group[string, int]
-		block := make(chan struct{})
-		unblock := make(chan struct{})
+		synctest.Test(t, func(t *testing.T) {
+			var g singleflight.Group[string, int]
+			unblock := make(chan struct{})
 
-		ch1 := g.DoChan("key", func() (int, error) {
-			close(block)
-			<-unblock
-			return 42, nil
+			ch1 := g.DoChan("key", func() (int, error) {
+				<-unblock
+				return 42, nil
+			})
+
+			// Wait until the first call is durably blocked inside fn before
+			// issuing the duplicate, so the suppression is deterministic.
+			synctest.Wait()
+
+			ch2 := g.DoChan("key", func() (int, error) {
+				t.Error("second call should not be executed")
+				return 0, nil
+			})
+
+			close(unblock)
+
+			res1 := <-ch1
+			if got, want := res1.Val, 42; got != want {
+				t.Errorf("first DoChan = %v; want %v", got, want)
+			}
+			if !res1.Shared {
+				t.Errorf("first DoChan shared = false; want true")
+			}
+
+			res2 := <-ch2
+			if got, want := res2.Val, 42; got != want {
+				t.Errorf("second DoChan = %v; want %v", got, want)
+			}
+			if !res2.Shared {
+				t.Errorf("second DoChan shared = false; want true")
+			}
 		})
-
-		<-block
-
-		ch2 := g.DoChan("key", func() (int, error) {
-			t.Error("second call should not be executed")
-			return 0, nil
-		})
-
-		close(unblock)
-
-		res1 := <-ch1
-		if got, want := res1.Val, 42; got != want {
-			t.Errorf("first DoChan = %v; want %v", got, want)
-		}
-		if !res1.Shared {
-			t.Errorf("first DoChan shared = false; want true")
-		}
-
-		res2 := <-ch2
-		if got, want := res2.Val, 42; got != want {
-			t.Errorf("second DoChan = %v; want %v", got, want)
-		}
-		if !res2.Shared {
-			t.Errorf("second DoChan shared = false; want true")
-		}
 	})
 }


### PR DESCRIPTION
## What

Upgrade the test suite and CI pipeline to Go 1.25 onwards.

## Tests

- Adopt **`testing/synctest`** (stabilized in Go 1.25) in `TestGroup_DoChan`.
- The `concurrent calls` subtest no longer relies on manual `block`/`unblock` channel coordination. It now runs inside a `synctest` bubble and uses **`synctest.Wait()`** to wait until the first call is durably blocked before issuing the duplicate, making suppression deterministic with no ordering race.
- `single call` is also wrapped in a bubble — as a bonus, `synctest` flags goroutine leaks, which matters since `DoChan` spawns goroutines.

`ExampleGroup_DoChan` is intentionally left unchanged: `synctest.Test` requires a `*testing.T`, which `Example` functions don't have, and examples are user-facing documentation of real API usage rather than tests.

## CI

- Test matrix → `['1.26.x', '1.25.x']`.
- **Removed `GOEXPERIMENT=nocoverageredesign`** (and the whole `include` block) — this experiment no longer exists on Go 1.26 (`unknown GOEXPERIMENT`) and would fail the build.
- Lint: toolchain `1.24`→`1.25` and `golangci-lint-action@v8`+`v2.1` → `@v9`+`v2.12`. Required, not cosmetic: the `testing/synctest` import was experimental in Go 1.24, so a 1.24-era golangci-lint would fail type-checking the test file. Go 1.26 support in golangci-lint is still in progress (golangci/golangci-lint#6272), but the lint job stays pinned to 1.25 while the matrix exercises 1.26 via plain `go test`.

## Verification

Locally with Go 1.26: `gofmt` clean, `go vet` passes, `go test ./... -race` passes, coverage **93.8%** (≥ 93 threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)